### PR TITLE
Remove note about cd-ing for jekyll

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ You will deploy this website locally by running it on a server on your computer.
 
 **Important if you're using the Learn IDE:** If you're using the Learn IDE and you cannot open up another terminal window (one for the jekyll server and one for the `rspec` command) you can just run the server as a background job (`jekyll serve &`). For more information on background jobs in bash, take a look at this readme: https://github.com/learn-co-curriculum/bash-background-jobs/
 
-* `cd` into `oo-student-scraper/fixtures/student-site`.
-* Then, in the terminal, run `jekyll serve`. You'll see something like this:
+* In the terminal, run `jekyll serve`. You'll see something like this:
 
 ```bash
 Configuration file: /Users/sophiedebenedetto/Desktop/Dev/oo-student-scraper/fixtures/student-site/_config.yml
@@ -43,6 +42,8 @@ Configuration file: /Users/sophiedebenedetto/Desktop/Dev/oo-student-scraper/fixt
 Most of that isn't important. We do want to pay attention to the second to last line, however. `Server address: http://127.0.0.1:4000/`. This tells us what port on our local server we can view the website at. Open up your browser and paste in `http://127.0.0.1:4000/` and you should see your student site! (note: `http://127.0.0.1` is often referred to as `localhost` and many browsers and other systems [use this term](https://en.wikipedia.org/wiki/Localhost). They are effectively interchangable, i.e., you could just as easily paste `localhost:4000` into a browser and it would be the same.)
 
 **Important:** Make sure you are running the site via the `jekyll server` when you run `rspec`. The tests are using the code you will write that sends a web request and scrapes a site. The web request that is getting sent is to `http://127.0.0.1:4000/`, the host and port that Jekyll will run the site on when you execute `jekyll serve`. So, if your connection to the server on port 4000 isn't running, the test suite can't execute your code.  You will need to open a second tab in your command line, in order to run `rspec` while Jekyll is also running.
+
+**Important if you're using the Learn IDE:** If you're using the Learn IDE you won't be able to see the output of the jekyll server (but the it's still needed for the test). If you want to look at the web site you can also run your `httpserver &`. Now you'll have two background tasks, one your can use to view the page (httpserver) and one so that test can see the page (jekyll server).
 
 ## Instructions
 


### PR DESCRIPTION
There was a note directing students to CD to run the jekyll server. Tests were already updated so this wasn't needed. Remove note to CD.

Add not instructing students to use `httpserver` with the Learn IDE to be able to view the site. 

@PeterBell 