### PR TITLE
Remove instructions to run multiple servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Don't worry! We've very cleverly solved this problem for the purposes of this pr
 
 You will deploy this website locally by running it on a server on your computer. Here's how:
 
-**Important if you're using the Learn IDE:** If you're using the Learn IDE and you cannot open up another terminal window (one for the jekyll server and one for the `rspec` command) you can just run the server as a background job (`jekyll serve &`). For more information on background jobs in bash, take a look at this readme: https://github.com/learn-co-curriculum/bash-background-jobs/
+**Important if you're using the Learn IDE:** If you're using the Learn IDE and you cannot open up another terminal window (one for the jekyll server and one for the `rspec` command) you can just run the server as a background job (`jekyll serve --detach`). For more information on background jobs in bash, take a look at this readme: https://github.com/learn-co-curriculum/bash-background-jobs/
 
 * In the terminal, run `jekyll serve`. You'll see something like this:
 
@@ -41,9 +41,9 @@ Configuration file: /Users/sophiedebenedetto/Desktop/Dev/oo-student-scraper/fixt
 
 Most of that isn't important. We do want to pay attention to the second to last line, however. `Server address: http://127.0.0.1:4000/`. This tells us what port on our local server we can view the website at. Open up your browser and paste in `http://127.0.0.1:4000/` and you should see your student site! (note: `http://127.0.0.1` is often referred to as `localhost` and many browsers and other systems [use this term](https://en.wikipedia.org/wiki/Localhost). They are effectively interchangable, i.e., you could just as easily paste `localhost:4000` into a browser and it would be the same.)
 
-**Important:** Make sure you are running the site via the `jekyll server` when you run `rspec`. The tests are using the code you will write that sends a web request and scrapes a site. The web request that is getting sent is to `http://127.0.0.1:4000/`, the host and port that Jekyll will run the site on when you execute `jekyll serve`. So, if your connection to the server on port 4000 isn't running, the test suite can't execute your code.  You will need to open a second tab in your command line, in order to run `rspec` while Jekyll is also running.
+**Important:** Make sure you are running the site via the `jekyll serve` when you run `rspec`. The tests are using the code you will write that sends a web request and scrapes a site. The web request that is getting sent is to `http://127.0.0.1:4000/`, the host and port that Jekyll will run the site on when you execute `jekyll serve`. So, if your connection to the server on port 4000 isn't running, the test suite can't execute your code.  You will need to open a second tab in your command line, in order to run `rspec` while Jekyll is also running.
 
-**Important if you're using the Learn IDE:** If you're using the Learn IDE you won't be able to see the output of the jekyll server (but the it's still needed for the test). If you want to look at the web site you can also run your `httpserver &`. Now you'll have two background tasks, one your can use to view the page (httpserver) and one so that test can see the page (jekyll server).
+**Important if you're using the Learn IDE:** The output at `Server address:` should look different. It won't be at `http://127.0.0.1`, and the port won't be `4000`. Follow the address `jekyll serve` gives you, and all should be well.
 
 ## Instructions
 


### PR DESCRIPTION
The current IDE doesn't support multiple servers, as only one port is reserved per user. However, the student should still be able to visit that port in order to see the site that `jekyll` is serving.